### PR TITLE
ensure input and output of dpldis have same length

### DIFF
--- a/pkg/R/pldis.R
+++ b/pkg/R/pldis.R
@@ -25,7 +25,6 @@
 #' 
 #' plot(x, dpldis(x, xmin, alpha), type="l")
 dpldis = function(x, xmin, alpha, log=FALSE) {
-  x = x[round(x) >= round(xmin)]
   xmin = floor(xmin)
   constant = zeta(alpha)
   if(xmin > 1) constant = constant - sum((1:(xmin-1))^(-alpha))

--- a/pkg/R/pldis.R
+++ b/pkg/R/pldis.R
@@ -30,8 +30,9 @@ dpldis = function(x, xmin, alpha, log=FALSE) {
   if(xmin > 1) constant = constant - sum((1:(xmin-1))^(-alpha))
   
   if(log) {
-    pdf = -alpha*log(x) - log(constant)
-    pdf[round(x) < round(xmin)] = -Inf
+    pdf = rep (-Inf, length (x))
+    indx = which (round(x) >= round(xmin))
+    pdf[indx] = -alpha*log(x[indx]) - log(constant)
   } else {
     pdf = x^(-alpha)/constant
     pdf[round(x) < round(xmin)] = 0


### PR DESCRIPTION
Heya Colin, i'm finally getting back around to my convolution ms. This PR solves the problem that the following lines work:
```
f <- function (x) dpldis (x, xmin = 1, alpha = 2)
integrate (f, 1, Inf)
```
while the following fail:
```
f2 <- function (x, y) f (y - x) * f (x)
integrate (f2, 1, Inf, y = 10)
```
The reason is simply because the offending line changes the length of the output of `dpldis`. The PR ensures that both cases work, and so allows `dpldis` to be passed to any other integration or convolution functions. This passes all tests, and I think has ~~only one consequence that it no longer ensures that the `log(x)` call does not receive any negative numbers - i'll leave that to you if that's okay.~~ - that's now taken care of as well.

------

Note another way to look at the problem: `xmin` may often be derived from some other routine, and not necessarily be explicitly known. The following will not work, and it will be difficult to reconcile the known `x` with the shorter result of `dpldis`. The commit also avoids that problem.
```
x <- 0:n
plot (x, dpldis (x, xmin = xmin, alpha = alpha))
```